### PR TITLE
Fix for issue #5

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,2 @@
+require 'geokit'
 require 'geokit-rails'


### PR DESCRIPTION
Hello Andre, 

Thanks a lot for your rails plugin :D

I created this pull request to resolve this WARNING 

matilde:weborder pablo$ rake gems:install
(in /Users/pablo/workspace/weborder)
WARNING: geokit-rails requires the Geokit gem. You either don't have the gem installed,
or you haven't told Rails to require it. If you're using a recent version of Rails: 
  config.gem "geokit" # in config/environment.rb
and of course install the gem: sudo gem install geokit

This WARNING is commented in this issue
https://github.com/andre/geokit-rails/issues#issue/5

I create this gem, that's works both as gem or plugin
https://github.com/phstc/acts_as_working_days

You have a plan to convert your plugin to a gem? If yes, I can convert it to a gem mantaining use as plugin option 

Best Regards,
Pablo Cantero
