### PR TITLE
Added mysql2 adapter

### DIFF
--- a/lib/geokit-rails/adapters/mysql2.rb
+++ b/lib/geokit-rails/adapters/mysql2.rb
@@ -1,0 +1,22 @@
+module Geokit
+  module Adapters
+    class Mysql2 < Abstract
+      
+      def sphere_distance_sql(lat, lng, multiplier)
+        %|
+          (ACOS(least(1,COS(#{lat})*COS(#{lng})*COS(RADIANS(#{qualified_lat_column_name}))*COS(RADIANS(#{qualified_lng_column_name}))+
+          COS(#{lat})*SIN(#{lng})*COS(RADIANS(#{qualified_lat_column_name}))*SIN(RADIANS(#{qualified_lng_column_name}))+
+          SIN(#{lat})*SIN(RADIANS(#{qualified_lat_column_name}))))*#{multiplier})
+         |
+      end
+      
+      def flat_distance_sql(origin, lat_degree_units, lng_degree_units)
+        %|
+          SQRT(POW(#{lat_degree_units}*(#{origin.lat}-#{qualified_lat_column_name}),2)+
+          POW(#{lng_degree_units}*(#{origin.lng}-#{qualified_lng_column_name}),2))
+         |
+      end
+      
+    end
+  end
+end


### PR DESCRIPTION
Added mysql2 adapter to get geokit-rails to work with the newer mysql2 gem (mysql2 gem link at bottom).  

I've been using this for a few months now with Rails 2.3.x and it appears to work the same as the mysql adapter.  I've seen a few issues with others not being able to get mysql2 to work (whether that be with Rails 2 or 3) and thought I'd submit a pull request.  There are other forks with this same fix, too, so figured it's time to get it in the main fork.

The mysql2.rb adapter file is the same as the mysql and postgresql adapters.

See the mysql2 repository (currently 569 followers) for information on mysql2: https://github.com/brianmario/mysql2
