### PR TITLE
Error with reload in rails 3

### DIFF
--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -269,6 +269,9 @@ module Geokit
             handle_order_with_include(options,origin,units,formula) if options.include?(:include) && options.include?(:order) && origin
           end
 
+          #in rails 3 reload fails because it passes nil instead of a hash
+          #this removes the nil
+          args.pop if args.last.nil? && args.size == 2
           # Restore options minus the extra options that we used for the
           # Geokit API.
           args.push(options)


### PR DESCRIPTION
In Rails 3 calling reload on a AR object returns an error. This is because the def for reload is:

reload(options = nil)

prepare_for_find_or_count does not take this into consideration when it pushes the options back on the args.

This patch just does a test and removes the nil if it exists.

I got a load error when I tried to run the tests so please do run them. If there's an issue I can work through the load error and sort it out.
