### PR TITLE
Fixes running rake commands when geokit is required but not installed yet.

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,4 @@
-require 'geokit-rails'
+# So we don't trip up the rake gems:install which I'm running to install the gem this plugin requires!
+unless $gems_rake_task
+  require 'geokit-rails'
+end


### PR DESCRIPTION
I added a little logic to not require geokit-rails when the gems rake tasks are being run so it can be installed by running rake gems:install.
