### PR TITLE
Mysql2 gem support for rails 2.*

### DIFF
--- a/lib/geokit-rails/adapters/mysql2.rb
+++ b/lib/geokit-rails/adapters/mysql2.rb
@@ -1,0 +1,22 @@
+module Geokit
+  module Adapters
+    class Mysql2 < Abstract
+      
+      def sphere_distance_sql(lat, lng, multiplier)
+        %|
+          (ACOS(least(1,COS(#{lat})*COS(#{lng})*COS(RADIANS(#{qualified_lat_column_name}))*COS(RADIANS(#{qualified_lng_column_name}))+
+          COS(#{lat})*SIN(#{lng})*COS(RADIANS(#{qualified_lat_column_name}))*SIN(RADIANS(#{qualified_lng_column_name}))+
+          SIN(#{lat})*SIN(RADIANS(#{qualified_lat_column_name}))))*#{multiplier})
+         |
+      end
+      
+      def flat_distance_sql(origin, lat_degree_units, lng_degree_units)
+        %|
+          SQRT(POW(#{lat_degree_units}*(#{origin.lat}-#{qualified_lat_column_name}),2)+
+          POW(#{lng_degree_units}*(#{origin.lng}-#{qualified_lng_column_name}),2))
+         |
+      end
+      
+    end
+  end
+end


### PR DESCRIPTION
Hey,

I have added support for mysql2 gem for older rails 2.*, when using ruby 1.9.2
