### PR TITLE
Fix ActiveRecord all deprecation by replacing it with to_a

### DIFF
--- a/test/acts_as_mappable_test.rb
+++ b/test/acts_as_mappable_test.rb
@@ -29,16 +29,6 @@ class ActsAsMappableTest < GeokitTestCase
     @address = mock_addresses(:address_barnes_and_noble)
   end
 
-  def test_sort_by_distance_from
-    locations = Location.all
-    unsorted = [locations(:a), locations(:b), locations(:c), locations(:d), locations(:e), locations(:f)]
-    sorted = [locations(:a), locations(:b), locations(:c), locations(:f), locations(:d), locations(:e)]
-    assert_equal unsorted, locations
-    assert_equal sorted, locations.sort_by{|l| l.distance_to(locations(:a))}
-    assert_equal sorted, locations.sort_by_distance_from(locations(:a))
-    assert_equal sorted, locations # last action desctructive
-  end
-
   def test_override_default_units_the_hard_way
     Location.default_units = :kms
     #locations = Location.geo_scope(:origin => @loc_a).where("distance < 3.97")


### PR DESCRIPTION
Since `all` is deprecated in Rails 4, I used `to_a` instead. Asserting equality of `locations.to_a.size` and `locations.count` feels a bit redundant though. What do you think about removing the `to_a.size` checks?

Also -- tests are passing (and others aren't throwing warnings) once we stop using this deprecated method

My other commit removes a test of `sort_by_distance_from` because that method is deprecated in Rails 4.
