### PR TITLE
Use a relative path when loading adapter

### DIFF
--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -93,7 +93,7 @@ module Geokit
       # A proxy to an instance of a finder adapter, inferred from the connection's adapter.
       def adapter
         @adapter ||= begin
-          require File.join(File.dirname(__FILE__), 'adapters', connection.adapter_name.downcase)
+          require File.join('geokit-rails', 'adapters', connection.adapter_name.downcase)
           klass = Adapters.const_get(connection.adapter_name.camelcase)
           klass.load(self) unless klass.loaded
           klass.new(self)


### PR DESCRIPTION
Using a relative path allows ActiveRecord style "plugin" gems to define
their own adapter in the geokit rails adapter directory, which will then
be loaded automatically.
