### PR TITLE
Arel::SqlLiteral has been moved in rails 42

### DIFF
--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -162,9 +162,9 @@ module Geokit
 
       #    if origin
       #      arel.distance_formula = distance_sql(origin, units, formula)
-      #      
+      #
       #      if arel.select_values.blank?
-      #        star_select = Arel::SqlLiteral.new(arel.quoted_table_name + '.*')
+      #        star_select = Arel::Nodes::SqlLiteral.new(arel.quoted_table_name + '.*')
       #        arel = arel.select(star_select)
       #      end
       #    end
@@ -234,14 +234,14 @@ module Geokit
         elsif options.has_key?(:range)
           "#{distance_column_name} >= #{options[:range].first} AND #{distance_column_name} <#{'=' unless options[:range].exclude_end?} #{options[:range].last}"
         end
-        Arel::SqlLiteral.new("(#{res})") if res.present?
+        Arel::Nodes::SqlLiteral.new("(#{res})") if res.present?
       end
 
       def bound_conditions(bounds)
         sw,ne = bounds.sw, bounds.ne
         lng_sql = bounds.crosses_meridian? ? "(#{qualified_lng_column_name}<#{ne.lng} OR #{qualified_lng_column_name}>#{sw.lng})" : "#{qualified_lng_column_name}>#{sw.lng} AND #{qualified_lng_column_name}<#{ne.lng}"
         res = "#{qualified_lat_column_name}>#{sw.lat} AND #{qualified_lat_column_name}<#{ne.lat} AND #{lng_sql}"
-        #Arel::SqlLiteral.new("(#{res})") if res.present?
+        #Arel::Nodes::SqlLiteral.new("(#{res})") if res.present?
         res if res.present?
       end
 


### PR DESCRIPTION
You will get following error:

```
NameError - uninitialized constant Arel::SqlLiteral:
  activesupport (4.2.0.rc2) lib/active_support/dependencies.rb:533:in
`load_missing_constant'
  activesupport (4.2.0.rc2) lib/active_support/dependencies.rb:184:in
`const_missing'
  geokit-rails (2.0.1) lib/geokit-rails/acts_as_mappable.rb:237:in
`distance_conditions'
  geokit-rails (2.0.1) lib/geokit-rails/acts_as_mappable.rb:108:in
`within'
```

Actually, this has been removed once in arel gems at 5.0 once but add
back, and it looks like they decide to remove it again in 6.0. I think
the safe way is to use `SqlLiteral` from `Arel::Nodes` module.
