### PR TITLE
Make nearest and farthest return scopes, not arrays

### DIFF
--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -137,16 +137,16 @@ module Geokit
         bounds  = extract_bounds_from_options(options)
         distance_column_name = distance_sql(origin, units, formula)
         #geo_scope(options).order("#{distance_column_name} asc")
-        order("#{distance_column_name} asc")
+        order("#{distance_column_name} #{options[:reverse] ? 'DESC' : 'ASC'}")
       end
 
       def closest(options = {})
-        by_distance(options).first(1)
+        by_distance(options).limit(1)
       end
       alias nearest closest
 
       def farthest(options = {})
-        by_distance(options).last(1)
+        by_distance({:reverse => true}.merge(options)).limit(1)
       end
 
       #def geo_scope(options = {})

--- a/test/acts_as_mappable_test.rb
+++ b/test/acts_as_mappable_test.rb
@@ -175,12 +175,20 @@ class ActsAsMappableTest < GeokitTestCase
     assert_equal @loc_a, Location.nearest(:origin =>[@loc_a.lat, @loc_a.lng]).first
   end
 
+  def test_find_nearest_is_scope
+    assert Location.nearest(:origin => @loc_a).respond_to? :where
+  end
+
   def test_find_farthest
     assert_equal @loc_e, Location.farthest(:origin => @loc_a).first
   end
 
   def test_find_farthest_with_coordinates
     assert_equal @loc_e, Location.farthest(:origin =>[@loc_a.lat, @loc_a.lng]).first
+  end
+
+  def test_find_farthest_is_scope
+    assert Location.farthest(:origin => @loc_a).respond_to? :where
   end
 
   def test_scoped_distance_column_in_select


### PR DESCRIPTION
Simple PR to avoid returning an array when a scope will provide even more flexibility.

Note: the old `geokit-rails3` was doing this too, so it's a compatibility issue also.