### PR TITLE
Update *_distance_sql to work with customized latitude and longitude attribute names

### DIFF
--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -315,8 +315,8 @@ module Geokit
       # Returns the distance SQL using the spherical world formula (Haversine).  The SQL is tuned
       # to the database in use.
       def sphere_distance_sql(origin, units)
-        # "origin" can be a Geokit::LatLng (with :lat and :lng methos), e.g. 
-        # when using geo_scope or it can be an ActsAsMappable with customized 
+        # "origin" can be a Geokit::LatLng (with :lat and :lng methods), e.g.
+        # when using geo_scope or it can be an ActsAsMappable with customized
         # latitude and longitude methods, e.g. when using distance_sql.
         lat = deg2rad(get_lat(origin))
         lng = deg2rad(get_lng(origin))
@@ -333,11 +333,13 @@ module Geokit
       end
 
       def get_lat(origin)
-        origin.respond_to?(:lat) ? origin.lat : origin.send(:"#{lat_column_name}")
+        origin.respond_to?(:lat) ? origin.lat \
+                                 : origin.send(:"#{lat_column_name}")
       end
 
       def get_lng(origin)
-        origin.respond_to?(:lng) ? origin.lng : origin.send(:"#{lng_column_name}")
+        origin.respond_to?(:lng) ? origin.lng \
+                                 : origin.send(:"#{lng_column_name}")
       end
 
     end # ClassMethods

--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -315,8 +315,11 @@ module Geokit
       # Returns the distance SQL using the spherical world formula (Haversine).  The SQL is tuned
       # to the database in use.
       def sphere_distance_sql(origin, units)
-        lat = deg2rad(origin.lat)
-        lng = deg2rad(origin.lng)
+	# "origin" can be a Geokit::LatLng (with :lat and :lng methos), e.g. when using geo_scope
+	# or it can be an ActsAsMappable with customized latitude and longitude methods, e.g. when using distance_sql.
+	lat = deg2rad(origin.respond_to?(:lat) ? origin.lat : origin.send(:"#{lat_column_name}"))
+	lng = deg2rad(origin.respond_to?(:lng) ? origin.lng : origin.send(:"#{lng_column_name}"))
+
         multiplier = units_sphere_multiplier(units)
 
         adapter.sphere_distance_sql(lat, lng, multiplier) if adapter
@@ -326,7 +329,7 @@ module Geokit
       # to the database in use.
       def flat_distance_sql(origin, units)
         lat_degree_units = units_per_latitude_degree(units)
-        lng_degree_units = units_per_longitude_degree(origin.lat, units)
+        lng_degree_units = units_per_longitude_degree(origin.respond_to?(:lat) ? origin.lat : origin.send(:"#{lat_column_name}"), units)
 
         adapter.flat_distance_sql(origin, lat_degree_units, lng_degree_units)
       end
@@ -339,8 +342,8 @@ module Geokit
       geo=Geokit::Geocoders::MultiGeocoder.geocode(address)
 
       if geo.success
-        self.send("#{lat_column_name}=", geo.lat)
-        self.send("#{lng_column_name}=", geo.lng)
+        self.send("#{lat_column_name}=", geo.send(:"#{lat_column_name}"))
+        self.send("#{lng_column_name}=", geo.send(:"#{lng_column_name}"))
       else
         errors.add(auto_geocode_field, auto_geocode_error_message)
       end

--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -315,13 +315,12 @@ module Geokit
       # Returns the distance SQL using the spherical world formula (Haversine).  The SQL is tuned
       # to the database in use.
       def sphere_distance_sql(origin, units)
-	# "origin" can be a Geokit::LatLng (with :lat and :lng methos), e.g. when using geo_scope
-	# or it can be an ActsAsMappable with customized latitude and longitude methods, e.g. when using distance_sql.
-	lat = deg2rad(origin.respond_to?(:lat) ? origin.lat : origin.send(:"#{lat_column_name}"))
-	lng = deg2rad(origin.respond_to?(:lng) ? origin.lng : origin.send(:"#{lng_column_name}"))
-
+        # "origin" can be a Geokit::LatLng (with :lat and :lng methos), e.g. 
+        # when using geo_scope or it can be an ActsAsMappable with customized 
+        # latitude and longitude methods, e.g. when using distance_sql.
+        lat = deg2rad(get_lat(origin))
+        lng = deg2rad(get_lng(origin))
         multiplier = units_sphere_multiplier(units)
-
         adapter.sphere_distance_sql(lat, lng, multiplier) if adapter
       end
 
@@ -329,9 +328,16 @@ module Geokit
       # to the database in use.
       def flat_distance_sql(origin, units)
         lat_degree_units = units_per_latitude_degree(units)
-        lng_degree_units = units_per_longitude_degree(origin.respond_to?(:lat) ? origin.lat : origin.send(:"#{lat_column_name}"), units)
-
+        lng_degree_units = units_per_longitude_degree(get_lat(origin), units)
         adapter.flat_distance_sql(origin, lat_degree_units, lng_degree_units)
+      end
+
+      def get_lat(origin)
+        origin.respond_to?(:lat) ? origin.lat : origin.send(:"#{lat_column_name}")
+      end
+
+      def get_lng(origin)
+        origin.respond_to?(:lng) ? origin.lng : origin.send(:"#{lng_column_name}")
       end
 
     end # ClassMethods


### PR DESCRIPTION
... as well as lat/lng attributes.

This has bugged me since Rails 3.0, please give it a look. Without this patch, it is not possible to use the distance_sql methods if you use custom lat/lng attribute names.

Thank you!