### PR TITLE
Remove unnecessary info from the Readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -723,7 +723,3 @@ AND the Mappable module goodness for free.
 *1. The configuration file*: Geokit for Rails uses a configuration file in config/initializers.
 You *must* add your own keys for the various geocoding services if you want to use geocoding.
 If you need to refer to the original template again, see the `assets/api_keys_template` file.
-
-*2. The gem dependency*: Geokit for Rails depends on the Geokit gem. Tell Rails about this
-dependency in `config/environment.rb`, within the initializer block:
-config.gem "geokit"


### PR DESCRIPTION
The `geokit` dependency is already specified in the gemspec file.