### PR TITLE
Check to see if adapter is loaded before requiring an explicit file

### DIFF
--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -93,7 +93,9 @@ module Geokit
       # A proxy to an instance of a finder adapter, inferred from the connection's adapter.
       def adapter
         @adapter ||= begin
-          require File.join('geokit-rails', 'adapters', connection.adapter_name.downcase)
+          unless Adapters.const_defined?(connection.adapter_name.camelcase)
+            require File.join('geokit-rails', 'adapters', connection.adapter_name.downcase)
+          end
           klass = Adapters.const_get(connection.adapter_name.camelcase)
           klass.load(self) unless klass.loaded
           klass.new(self)

--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -95,7 +95,7 @@ module Geokit
         @adapter ||= begin
           unless Adapters.const_defined?(connection.adapter_name.camelcase)
             filename = connection.adapter_name.downcase
-            require File.join('geokit-rails', 'adapters', filename)
+            require File.join("geokit-rails", "adapters", filename)
           end
           klass = Adapters.const_get(connection.adapter_name.camelcase)
           klass.load(self) unless klass.loaded

--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -94,7 +94,8 @@ module Geokit
       def adapter
         @adapter ||= begin
           unless Adapters.const_defined?(connection.adapter_name.camelcase)
-            require File.join('geokit-rails', 'adapters', connection.adapter_name.downcase)
+            filename = connection.adapter_name.downcase
+            require File.join('geokit-rails', 'adapters', filename)
           end
           klass = Adapters.const_get(connection.adapter_name.camelcase)
           klass.load(self) unless klass.loaded


### PR DESCRIPTION
This change simply checks to see if the database-specific adapter is already loaded before it tries to require a file with an explicit path. With this change, projects that use geokit-rails can choose to provide their own adapters in initializers without causing unnecessary UnsupportedAdapter errors.

This simple change is the end of a very long story for my team. (Read on if you dare!) Our Rails app uses a custom database adapter to perform cryptographic functions (the excellent [pgcrypto](https://github.com/Plinq/pgcrypto) adapter by @flipsasser). For Geokit's purposes, the PGCrypto adapter can be treated identically to the PostgreSQL adapter. We had a lot of trouble getting geokit-rails to handle the situation correctly:
* Out of the box, line 101 was raising an UnsupportedAdapter error. We knew that the code solution was as simple as `class Geokit::Adapters::PGCrypto < Geokit::Adapters::PostgreSQL; end` but the question was where to put that code.
* First we tried placing a file in our own project at `/lib/geokit-rails/adapters/pgcrypto.rb`. That allowed geokit-rails to work, but only in lazy-loaded environments. In eager-loaded environments, Rails would find that file before geokit-rails did, and it would raise a NameError because it expects a class like `Geokit::Adapters::PGCrypto` to be found at the path `/lib/geokit/adapters/pgcrypto.rb` instead.
* Next we tried placing the code at `/lib/geokit/adapters/pgcrypto.rb`, where Rails would expect it to be. This allows eager-loading to work, but geokit-rails would still trip and fall over anyway because the `require` on line 96 was explicitly looking for a file under `geokit-rails/`.
* Trying to be clever, we placed a file at `/lib/geokit-rails/adapters/pgcrypto.rb` that simply loaded the file at `/lib/geokit/adapters/pgcrypto.rb`, but this suffered from the same problem where Rails would raise a NameError when trying to eager-load the file.

After tearing our hair out for a while, we decided that the best solution was to fork the gem and submit the PR you see here. We think this is a pretty common-sense solution that might benefit others without requiring any other changes.