### PR TITLE
Add NOT NULL checks for latitude and longitude

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@ Geokit Rails
 
 [![Gem Version](https://badge.fury.io/rb/geokit-rails.png)](http://badge.fury.io/rb/geokit-rails)
 [![Build Status](https://travis-ci.org/geokit/geokit-rails.png?branch=master)](https://travis-ci.org/geokit/geokit-rails)
-[![Coverage Status](https://coveralls.io/repos/geokit/geokit-rails/badge.png)](https://coveralls.io/r/geokit/geokit-rails)
+[![Coverage Status](https://coveralls.io/repos/geokit/geokit-rails/badge.png?branch=master)](https://coveralls.io/r/geokit/geokit-rails)
 [![Dependency Status](https://gemnasium.com/geokit/geokit-rails.png?travis)](https://gemnasium.com/geokit/geokit-rails)
 [![Code Climate](https://codeclimate.com/github/geokit/geokit-rails.png)](https://codeclimate.com/github/geokit/geokit-rails)
 

--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -108,7 +108,7 @@ module Geokit
       def within(distance, options = {})
         options[:within] = distance
         #geo_scope(options)
-        not_null_latlng.where(distance_conditions(options))
+        with_latlng.where(distance_conditions(options))
       end
       alias inside within
 
@@ -140,10 +140,10 @@ module Geokit
         bounds  = extract_bounds_from_options(options)
         distance_column_name = distance_sql(origin, units, formula)
         #geo_scope(options).order("#{distance_column_name} asc")
-        not_null_latlng.order("#{distance_column_name} #{options[:reverse] ? 'DESC' : 'ASC'}")
+        with_latlng.order("#{distance_column_name} #{options[:reverse] ? 'DESC' : 'ASC'}")
       end
 
-      def not_null_latlng
+      def with_latlng
         where("#{qualified_lat_column_name} IS NOT NULL AND #{qualified_lng_column_name} IS NOT NULL")
       end
 

--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -105,7 +105,7 @@ module Geokit
       def within(distance, options = {})
         options[:within] = distance
         #geo_scope(options)
-        where(distance_conditions(options))
+        not_null_latlng.where(distance_conditions(options))
       end
       alias inside within
 
@@ -137,7 +137,11 @@ module Geokit
         bounds  = extract_bounds_from_options(options)
         distance_column_name = distance_sql(origin, units, formula)
         #geo_scope(options).order("#{distance_column_name} asc")
-        order("#{distance_column_name} #{options[:reverse] ? 'DESC' : 'ASC'}")
+        not_null_latlng.order("#{distance_column_name} #{options[:reverse] ? 'DESC' : 'ASC'}")
+      end
+
+      def not_null_latlng
+        where("#{qualified_lat_column_name} IS NOT NULL AND #{qualified_lng_column_name} IS NOT NULL")
       end
 
       def closest(options = {})

--- a/test/acts_as_mappable_test.rb
+++ b/test/acts_as_mappable_test.rb
@@ -449,7 +449,7 @@ class ActsAsMappableTest < GeokitTestCase
   end
 
   def test_sort_by_distance_from
-    locations = Location.all
+    locations = Location.not_null_latlng.all
     unsorted = [locations(:a), locations(:b), locations(:c), locations(:d), locations(:e), locations(:f)]
     sorted   = [locations(:a), locations(:b), locations(:c), locations(:f), locations(:d), locations(:e)]
     assert_equal sorted, locations.sort_by{|l| l.distance_to(locations(:a))}

--- a/test/acts_as_mappable_test.rb
+++ b/test/acts_as_mappable_test.rb
@@ -449,7 +449,7 @@ class ActsAsMappableTest < GeokitTestCase
   end
 
   def test_sort_by_distance_from
-    locations = Location.not_null_latlng.all
+    locations = Location.with_latlng.all
     unsorted = [locations(:a), locations(:b), locations(:c), locations(:d), locations(:e), locations(:f)]
     sorted   = [locations(:a), locations(:b), locations(:c), locations(:f), locations(:d), locations(:e)]
     assert_equal sorted, locations.sort_by{|l| l.distance_to(locations(:a))}

--- a/test/fixtures/custom_locations.yml
+++ b/test/fixtures/custom_locations.yml
@@ -52,3 +52,10 @@ f:
   postal_code: 75039
   latitude: 32.895155
   longitude: -96.958444
+g:
+  id: 7
+  company_id: 2
+  street: 4711 N Macarthur Blvd # 160
+  city: Nowhere
+  state: TX
+  postal_code: 12345

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -52,3 +52,10 @@ f:
   postal_code: 75039
   lat: 32.895155
   lng: -96.958444
+g:
+  id: 7
+  company_id: 2
+  street: 4711 N Macarthur Blvd # 160
+  city: Nowhere
+  state: TX
+  postal_code: 12345


### PR DESCRIPTION
... otherwise nonsense values are being returned for distance calculations involving such objects.
Added a test fixture without latitude and longitude to make existing tests fail if they do not test for NULL lat/lng values.