### PR TITLE
fix-Mysql2AdapterUndefinedMethodLoaded

### DIFF
--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -98,6 +98,13 @@ module Geokit
             require File.join("geokit-rails", "adapters", filename)
           end
           klass = Adapters.const_get(connection.adapter_name.camelcase)
+          if klass.class == Module
+            # For some reason Mysql2 adapter was defined in Adapters.constants but was Module instead of a Class
+            filename = connection.adapter_name.downcase
+            require File.join("geokit-rails", "adapters", filename)
+            # Re-init the klass after require
+            klass = Adapters.const_get(connection.adapter_name.camelcase)
+          end
           klass.load(self) unless klass.loaded
           klass.new(self)
         rescue LoadError


### PR DESCRIPTION
Mysql2 was present in Adapters.constants as a Module, and require was never called, resulting in Undefined method exception. Make sure the require is called if the const_get returns a Module and not a Class.

Fix to the issue: https://github.com/geokit/geokit-rails/issues/89

Do you think this is a good fix? Thanks.