### PR TITLE
Silence deprecation message for having before_filter if running on Rails 5.1

### DIFF
--- a/lib/geokit-rails/geocoder_control.rb
+++ b/lib/geokit-rails/geocoder_control.rb
@@ -3,15 +3,17 @@ require 'active_support/concern'
 module Geokit
   module GeocoderControl
     extend ActiveSupport::Concern
-  
+
     included do
-      if self.respond_to? :before_action
-        self.send :before_action, :set_geokit_domain
-      elsif self.respond_to? :before_filter
-        self.send :before_filter, :set_geokit_domain
+      ActiveSupport::Deprecation.silence do
+        if self.respond_to? :before_action
+          self.send :before_action, :set_geokit_domain
+        elsif self.respond_to? :before_filter
+          self.send :before_filter, :set_geokit_domain
+        end
       end
     end
-    
+
     def set_geokit_domain
       Geokit::Geocoders::domain = request.domain
       logger.debug("Geokit is using the domain: #{Geokit::Geocoders::domain}")

--- a/lib/geokit-rails/ip_geocode_lookup.rb
+++ b/lib/geokit-rails/ip_geocode_lookup.rb
@@ -12,10 +12,12 @@ module Geokit
     # Class method to mix into active record.
     module ClassMethods # :nodoc:
       def geocode_ip_address(filter_options = {})
-        if respond_to? :before_action
-          before_action :store_ip_location, filter_options
-        else
-          before_filter :store_ip_location, filter_options
+        ActiveSupport::Deprecation.silence do
+          if respond_to? :before_action
+            before_action :store_ip_location, filter_options
+          else
+            before_filter :store_ip_location, filter_options
+          end
         end
       end
     end


### PR DESCRIPTION
`DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from block in <module:GeocoderControl> at /Users/chayelheinsen/.rvm/gems/ruby-2.3.1/gems/geokit-rails-2.1.0/lib/geokit-rails/geocoder_control.rb:9)
` This PR will remove this from displaying in the terminal if running on Rails 5.1.