### PR TITLE
Fixed PG::InvalidColumnReference with DISTINCT & by_distance

### DIFF
--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -152,8 +152,12 @@ module Geokit
         origin  = extract_origin_from_options(options)
         units   = extract_units_from_options(options)
         formula = extract_formula_from_options(options)
-        distance_column_name = distance_sql(origin, units, formula)
-        with_latlng.order("#{distance_column_name} #{options[:reverse] ? 'DESC' : 'ASC'}")
+
+        arel = self.is_a?(ActiveRecord::Relation) ? self : self.all
+
+        distance_formula = distance_sql(origin, units, formula).gsub(/\s+/, '')
+        with_latlng.select("#{arel.quoted_table_name}.*", "#{distance_formula} AS #{distance_column_name}")
+                   .order("#{distance_column_name} #{options[:reverse] ? 'DESC' : 'ASC'}")
       end
 
       def with_latlng


### PR DESCRIPTION
I am using PG and Rails 5.1.

I had a pretty complex statement that used both `.distinct` and the `.by_distance` scope, and I was getting this error:

PG::InvalidColumnReference: ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list

I dug down a bit and found that it was happening because the formula was right in the ORDER BY clause, and Postgres was having none of it.

This PR is a fix that worked for me. Whether it's something should be merged in, I don't know. But it did fix a bug for me, and it may for others, as well. If there is some further refactoring I could do to get this merged, let me know.

Basically, I am looking for feedback.