### PR TITLE
Fix unsafe raw SQL warning

### DIFF
--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -153,7 +153,7 @@ module Geokit
         units   = extract_units_from_options(options)
         formula = extract_formula_from_options(options)
         distance_column_name = distance_sql(origin, units, formula)
-        with_latlng.order("#{distance_column_name} #{options[:reverse] ? 'DESC' : 'ASC'}")
+        with_latlng.order(Arel.sql("#{distance_column_name} #{options[:reverse] ? 'DESC' : 'ASC'}"))
       end
 
       def with_latlng

--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -153,7 +153,9 @@ module Geokit
         units   = extract_units_from_options(options)
         formula = extract_formula_from_options(options)
         distance_column_name = distance_sql(origin, units, formula)
-        with_latlng.order(Arel.sql("#{distance_column_name} #{options[:reverse] ? 'DESC' : 'ASC'}"))
+        with_latlng.order(Arel.sql(
+          "#{distance_column_name} #{options[:reverse] ? 'DESC' : 'ASC'}"
+        ))
       end
 
       def with_latlng

--- a/test/boot.rb
+++ b/test/boot.rb
@@ -1,8 +1,8 @@
 require 'pathname'
 
-require 'active_support/version'
+require "active_support/version"
 require 'active_support/test_case'
-require 'active_support/testing/autorun' if ActiveSupport::VERSION::MAJOR >= 4
+require "active_support/testing/autorun" if ActiveSupport::VERSION::MAJOR >= 4
 
 require 'active_record'
 require 'active_record/fixtures'

--- a/test/boot.rb
+++ b/test/boot.rb
@@ -1,7 +1,8 @@
 require 'pathname'
 
-require 'test/unit'
+require 'active_support/version'
 require 'active_support/test_case'
+require 'active_support/testing/autorun' if ActiveSupport::VERSION::MAJOR >= 4
 
 require 'active_record'
 require 'active_record/fixtures'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,7 +43,11 @@ class GeokitTestCase < ActiveSupport::TestCase
   end
   
   self.fixture_path = (PLUGIN_ROOT + 'test/fixtures').to_s
-  self.use_transactional_fixtures = true
+  if Rails::VERSION::MAJOR >= 5
+    self.use_transactional_tests = true
+  else
+    self.use_transactional_fixtures = true
+  end
   self.use_instantiated_fixtures  = false
   
   fixtures :all 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,6 +34,8 @@ require 'geokit-rails'
 ActiveRecord::Base.send(:include, Geokit::ActsAsMappable::Glue)
 ActionController::Base.send(:include, Geokit::GeocoderControl)
 ActionController::Base.send(:include, Geokit::IpGeocodeLookup)
+# Rails >= 4 requires models classes to be loaded before fixtures are created
+Dir[PLUGIN_ROOT + "test/models/*.rb"].each { |file| require file }
 
 class GeokitTestCase < ActiveSupport::TestCase
   begin


### PR DESCRIPTION
Starting from Rails 5.2, there's a deprecation warning on using raw SQL fragments in some AR methods, including `order`, cf [Rails 5.2 changelog](http://guides.rubyonrails.org/5_2_release_notes.html#active-record-notable-changes) :

> Require raw SQL fragments to be explicitly marked when used in relation query methods. 

The warning precises :

> Non-attribute arguments will be disallowed in Rails 6.0

We just need to wrap the SQL in `Arel.sql(...)` to remove the warning. Tests config is also fixed for Rails >= 4 (fixing #129).