### PR TITLE
add cockroachdb adapter

### DIFF
--- a/lib/geokit-rails/adapters/cockroachdb.rb
+++ b/lib/geokit-rails/adapters/cockroachdb.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Geokit
+  module Adapters
+    class CockroachDB < PostgreSQL
+    end
+  end
+end


### PR DESCRIPTION
Cockroachdb adapter uses the postgres adpater to handle SQL queries.
Admittedly my  Geometry is not brilliant but this does work, the accuracy I am not 100% sure about.