### PR TITLE
Provide support for PostGIS, fixed deprecation warning.

### DIFF
--- a/lib/geokit-rails/acts_as_mappable.rb
+++ b/lib/geokit-rails/acts_as_mappable.rb
@@ -159,7 +159,7 @@ module Geokit
       end
 
       def with_latlng
-        where("#{qualified_lat_column_name} IS NOT NULL AND #{qualified_lng_column_name} IS NOT NULL")
+        where("? IS NOT NULL AND ? IS NOT NULL", qualified_lat_column_name, qualified_lng_column_name)
       end
 
       def closest(options = {})

--- a/lib/geokit-rails/adapters/postgis.rb
+++ b/lib/geokit-rails/adapters/postgis.rb
@@ -1,6 +1,6 @@
 module Geokit
   module Adapters
-    class Postgis < Abstract
+    class PostGIS < Abstract
       
       def sphere_distance_sql(lat, lng, multiplier)
         %|

--- a/lib/geokit-rails/adapters/postgis.rb
+++ b/lib/geokit-rails/adapters/postgis.rb
@@ -1,0 +1,22 @@
+module Geokit
+  module Adapters
+    class Postgis < Abstract
+      
+      def sphere_distance_sql(lat, lng, multiplier)
+        %|
+          (ACOS(least(1,COS(#{lat})*COS(#{lng})*COS(RADIANS(#{qualified_lat_column_name}))*COS(RADIANS(#{qualified_lng_column_name}))+
+          COS(#{lat})*SIN(#{lng})*COS(RADIANS(#{qualified_lat_column_name}))*SIN(RADIANS(#{qualified_lng_column_name}))+
+          SIN(#{lat})*SIN(RADIANS(#{qualified_lat_column_name}))))*#{multiplier})
+         |
+      end
+      
+      def flat_distance_sql(origin, lat_degree_units, lng_degree_units)
+        %|
+          SQRT(POW(#{lat_degree_units}*(#{origin.lat}-#{qualified_lat_column_name}),2)+
+          POW(#{lng_degree_units}*(#{origin.lng}-#{qualified_lng_column_name}),2))
+         |
+      end
+      
+    end
+  end
+end


### PR DESCRIPTION
This request addresses the following two problems:

1) PostGIS was not supported, so the adaptor for Postgres was simply duplicated with a new name
    - There's definitely better integration that can be achieved with native PostGIS methods, but I'm not experienced enough to do that

2) Fixed a deprecation warning ahead of Rails 6
    - String interpolation is going to become unsupported soon, so the safer placeholder substitution was used instead
