### PR TITLE
Travis: Run tests with provided bundler, drop sudo: false setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,5 @@ matrix:
     - rvm: 2.1
       gemfile: gemfiles/rails5.gemfile
 script: "bundle exec rake coverage"
-before_install:
-  - gem install bundler
 bundler_args: --retry 5
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,4 @@ script: "bundle exec rake coverage"
 before_install:
   - gem install bundler
 bundler_args: --retry 5
-sudo: false
 cache: bundler

--- a/gemfiles/rails3.gemfile
+++ b/gemfiles/rails3.gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 group :development, :test do
   gem 'activerecord', '~> 3.2.0'
+  gem 'sqlite3', '~> 1.3.5'
 end
 
 gemspec :path => "../"

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :development, :test do
   gem 'activerecord', '~> 4.0'
-  gem 'test-unit'
+  gem 'sqlite3', '1.3.7'
 end
 
 gemspec :path => "../"

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 group :development, :test do
   gem 'activerecord', '~> 5.0'
-  gem 'test-unit'
 end
 
 gemspec :path => "../"


### PR DESCRIPTION
### Use existing Bundler

To try passing the build in CI, this PR tries to **run tests with the provided `bundle` command**, instead of trying to install one. Result: This stops the error condition that some of the CI matrix elements could not start building.

### Drop `sudo: false` Travis directive

In addition: This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

### `gemfiles/`: Drop `test-unit` duplicates, pick version of `sqlite3`

In gemfiles, there as a duplication, now removed.

`rails3` gemfile asked for a `sqlite3` which was not provided.