### PR TITLE
Use Arel for `IS NOT NULL` SQL condition

### DIFF
--- a/lib/geokit-rails/acts_as_mappable/class_methods.rb
+++ b/lib/geokit-rails/acts_as_mappable/class_methods.rb
@@ -71,7 +71,7 @@ module Geokit
       end
 
       def with_latlng
-        where("?.? IS NOT NULL AND ?.? IS NOT NULL", table_name, lat_column_name, table_name, lng_column_name)
+        where(arel_table[lat_column_name].not_eq(nil).and(arel_table[lng_column_name].not_eq(nil)))
       end
 
       def closest(options = {})


### PR DESCRIPTION
This will properly format the SQL condition depending on the database

* `` WHERE `users`.`lat` IS NOT NULL AND `users`.`lng` IS NOT NULL `` for MySQL
* `WHERE 'users'.'lat' IS NOT NULL AND 'users'.'lng' IS NOT NULL` for Postgresql