### PR TITLE
Add support for Trilogy MySQL adapter

### DIFF
--- a/lib/geokit-rails/acts_as_mappable/class_methods.rb
+++ b/lib/geokit-rails/acts_as_mappable/class_methods.rb
@@ -7,7 +7,7 @@ module Geokit
       # A proxy to an instance of a finder adapter, inferred from the connection's adapter.
       def geokit_finder_adapter
         @geokit_finder_adapter ||= begin
-                                     unless Adapters.const_defined?(connection.adapter_name.camelcase)
+                                     unless Adapters.const_defined?(connection.adapter_name.camelcase, false)
                                        filename = connection.adapter_name.downcase
                                        require File.join("geokit-rails", "adapters", filename)
                                      end

--- a/lib/geokit-rails/adapters/trilogy.rb
+++ b/lib/geokit-rails/adapters/trilogy.rb
@@ -1,0 +1,8 @@
+require 'geokit-rails/adapters/mysql'
+
+module Geokit
+  module Adapters
+    class Trilogy < MySQL
+    end
+  end
+end


### PR DESCRIPTION
Works for our use but did not fully test.  Had to add the false argument to const_defined? in class_methods.rb or else the geokit_finder_adapter method would not load the new adapter.  Not sure if that was an issue for other adapters or just the new one.