### PR TITLE
Add Trilogy adapter support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,152 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.0', '3.1', '3.2', '3.3']
+        gemfile:
+          - rails_7.0
+          - rails_7.1
+          - rails_7.2
+        exclude:
+          # Rails 7.2 requires Ruby 3.1+
+          - ruby: '3.0'
+            gemfile: rails_7.2
+
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test
+
+  test-mysql:
+    name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }} / MySQL
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: '3.2'
+            gemfile: rails_7.1
+          - ruby: '3.3'
+            gemfile: rails_7.2
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: tests
+          MYSQL_PASSWORD: tests
+          MYSQL_DATABASE: geokit_rails_tests
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DB: mysql
+      DB_HOST: 127.0.0.1
+      DB_USERNAME: tests
+      DB_PASSWORD: tests
+      DB_NAME: geokit_rails_tests
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test
+
+  test-trilogy:
+    name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }} / Trilogy
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: '3.2'
+            gemfile: rails_7.1
+          - ruby: '3.3'
+            gemfile: rails_7.2
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: tests
+          MYSQL_PASSWORD: tests
+          MYSQL_DATABASE: geokit_rails_tests
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DB: trilogy
+      DB_HOST: 127.0.0.1
+      DB_USERNAME: tests
+      DB_PASSWORD: tests
+      DB_NAME: geokit_rails_tests
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Check gem can be built
+        run: gem build geokit-rails.gemspec

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Bundler
 # http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
 Gemfile.lock
+gemfiles/*.lock
 
 # Test log files
 test/*-debug.log

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+group :development, :test do
+  gem 'activerecord', '~> 7.0'
+  gem 'sqlite3', '~> 1.4'
+end
+
+gemspec :path => "../"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+group :development, :test do
+  gem 'activerecord', '~> 7.1'
+end
+
+gemspec :path => "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+group :development, :test do
+  gem 'activerecord', '~> 7.2'
+end
+
+gemspec :path => "../"

--- a/geokit-rails.gemspec
+++ b/geokit-rails.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mocha", "~> 0.9"
   spec.add_development_dependency 'coveralls_reborn'
   spec.add_development_dependency "mysql2", ">= 0.2"
+  spec.add_development_dependency "trilogy"
   # spec.add_development_dependency "activerecord-mysql2spatial-adapter"
   spec.add_development_dependency "pg", ">= 0.10"
   spec.add_development_dependency "sqlite3"

--- a/lib/geokit-rails/acts_as_mappable/class_methods.rb
+++ b/lib/geokit-rails/acts_as_mappable/class_methods.rb
@@ -7,17 +7,18 @@ module Geokit
       # A proxy to an instance of a finder adapter, inferred from the connection's adapter.
       def geokit_finder_adapter
         @geokit_finder_adapter ||= begin
-                                     unless Adapters.const_defined?(connection.adapter_name.camelcase)
+                                     adapter_name = connection.adapter_name.camelcase
+                                     unless Adapters.const_defined?(adapter_name, false)
                                        filename = connection.adapter_name.downcase
                                        require File.join("geokit-rails", "adapters", filename)
                                      end
-                                     klass = Adapters.const_get(connection.adapter_name.camelcase)
+                                     klass = Adapters.const_get(adapter_name, false)
                                      if klass.class == Module
                                        # For some reason Mysql2 adapter was defined in Adapters.constants but was Module instead of a Class
                                        filename = connection.adapter_name.downcase
                                        require File.join("geokit-rails", "adapters", filename)
                                        # Re-init the klass after require
-                                       klass = Adapters.const_get(connection.adapter_name.camelcase)
+                                       klass = Adapters.const_get(adapter_name, false)
                                      end
                                      klass.load(self) unless klass.loaded || skip_loading
                                      klass.new(self)

--- a/lib/geokit-rails/adapters/trilogy.rb
+++ b/lib/geokit-rails/adapters/trilogy.rb
@@ -1,0 +1,8 @@
+require 'geokit-rails/adapters/mysql'
+
+module Geokit
+  module Adapters
+    class Trilogy < MySQL
+    end
+  end
+end

--- a/test/boot.rb
+++ b/test/boot.rb
@@ -19,11 +19,15 @@ ADAPTER = ENV['DB'] || 'sqlite'
 $LOAD_PATH << (PLUGIN_ROOT + 'lib')
 $LOAD_PATH << (PLUGIN_ROOT + 'test/models')
 
+require 'erb'
+
 config_file = PLUGIN_ROOT + 'test/database.yml'
+config_content = ERB.new(IO.read(config_file)).result
 if defined?(YAML.safe_load)
-  db_config   = YAML.safe_load(IO.read(config_file), aliases: true)
+  db_config = YAML.safe_load(config_content, aliases: true)
 else
-  db_config   = YAML::load(IO.read(config_file))
+  # Fallback for older Ruby versions that don't support YAML.safe_load
+  db_config = YAML.load(config_content) # rubocop:disable Security/YAMLLoad
 end
 logger_file = PLUGIN_ROOT + "test/#{ADAPTER}-debug.log"
 schema_file = PLUGIN_ROOT + 'test/schema.rb'

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,20 +1,20 @@
 base: &base
-  host: localhost
-  username: tests
-  password: 
+  host: <%= ENV.fetch('DB_HOST', 'localhost') %>
+  username: <%= ENV.fetch('DB_USERNAME', 'tests') %>
+  password: <%= ENV.fetch('DB_PASSWORD', '') %>
 
 mysql:
-  adapter: mysql
-  database: geokit_rails_tests
+  adapter: mysql2
+  database: <%= ENV.fetch('DB_NAME', 'geokit_rails_tests') %>
   <<: *base
 
 mysql2spatial:
   adapter: mysql2spatial
-  database: geokit_rails_tests
+  database: <%= ENV.fetch('DB_NAME', 'geokit_rails_tests') %>
 
 postgresql:
   adapter: postgresql
-  database: geokit_rails_tests
+  database: <%= ENV.fetch('DB_NAME', 'geokit_rails_tests') %>
   <<: *base
 
 sqlserver:
@@ -26,3 +26,8 @@ sqlserver:
 sqlite:
   adapter: sqlite3
   database: test/test.sqlite3
+
+trilogy:
+  adapter: trilogy
+  database: <%= ENV.fetch('DB_NAME', 'geokit_rails_tests') %>
+  <<: *base

--- a/test/ip_geocode_lookup_test.rb
+++ b/test/ip_geocode_lookup_test.rb
@@ -30,12 +30,16 @@ class IpGeocodeLookupTest < ActionDispatch::IntegrationTest#ActiveSupport::TestC
   end
   
   def test_location_in_cookie
+    Geokit::Geocoders::MultiGeocoder.expects(:geocode).with('good ip')
+                                    .returns(@success)
     get '/cookietest'
     assert_not_nil cookies[:geo_location]
     assert_equal @success.to_json, cookies[:geo_location]
   end
 
   def test_location_in_session
+    Geokit::Geocoders::MultiGeocoder.expects(:geocode).with('good ip')
+                                    .returns(@success)
     get '/sessiontest'
     assert_response :success
     assert_equal @success, Geokit::GeoLoc.new(JSON.parse(session[:geo_location]).transform_keys(&:to_sym))

--- a/test/tasks.rake
+++ b/test/tasks.rake
@@ -18,7 +18,7 @@ Rake::TestTask.new(:test) do |test|
   test.verbose = true
 end
 
-%w(mysql postgresql sqlserver sqlite).each do |configuration|
+%w(mysql postgresql sqlserver sqlite trilogy).each do |configuration|
   EnvTestTask.new("test_#{configuration}") do |t|
     t.pattern = 'test/*_test.rb'
     t.verbose = true
@@ -28,7 +28,7 @@ end
 end
 
 desc 'Test available databases.'
-task :test_databases => %w(test_mysql test_postgresql test_sqlserver test_sqlite)
+task :test_databases => %w(test_mysql test_postgresql test_sqlserver test_sqlite test_trilogy)
 
 desc "Generate SimpleCov test coverage and open in your browser"
 task :coverage do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,6 @@ unless ENV['COVERAGE'] == 'off'
   COVERAGE_THRESHOLD = 35
   require 'simplecov'
   require 'simplecov-rcov'
-  gem 'coveralls_reborn', '~> 0.26.0'
   require 'coveralls'
   Coveralls.wear!
 
@@ -60,14 +59,20 @@ class GeokitTestCase < ActiveSupport::TestCase
   rescue NameError
     puts "You appear to be using a pre-2.3 version of Rails. No need to include ActiveRecord::TestFixtures."
   end
-  
-  self.fixture_path = (PLUGIN_ROOT + 'test/fixtures').to_s
+
+  # Rails 7.1+ uses fixture_paths instead of fixture_path
+  if respond_to?(:fixture_paths=)
+    self.fixture_paths = [(PLUGIN_ROOT + 'test/fixtures').to_s]
+  else
+    self.fixture_path = (PLUGIN_ROOT + 'test/fixtures').to_s
+  end
+
   if Rails::VERSION::MAJOR >= 5
     self.use_transactional_tests = true
   else
     self.use_transactional_fixtures = true
   end
   self.use_instantiated_fixtures  = false
-  
-  fixtures :all 
+
+  fixtures :all
 end


### PR DESCRIPTION
## Summary

- Add Trilogy adapter support for MySQL-compatible connections via the `trilogy` gem
- Fix adapter name resolution to avoid collision with top-level Ruby constants (e.g., `::Trilogy`)
- Add GitHub Actions CI workflow with comprehensive matrix testing

## Changes

### Trilogy Adapter
- New `Geokit::Adapters::Trilogy` class inheriting from MySQL adapter
- Add `trilogy` gem as development dependency
- Add trilogy database configuration with environment variable support

### CI/CD
- GitHub Actions workflow with matrix testing:
  - **SQLite**: Ruby 3.0-3.3, Rails 7.0-7.2
  - **MySQL**: Ruby 3.2-3.3, Rails 7.1-7.2
  - **Trilogy**: Ruby 3.2-3.3, Rails 7.1-7.2 (MySQL 5.7)
- Gemfiles for Rails 7.0, 7.1, and 7.2

### Bug Fixes
- Fix `const_defined?`/`const_get` to use `inherit=false` to avoid matching top-level constants
- Fix test compatibility with Rails 7.1+ (`fixture_paths` vs `fixture_path`)
- Fix flaky IP geocode lookup tests by adding missing mock expectations

## Test Plan

- [x] CI passes for all matrix combinations
- [x] Trilogy adapter correctly inherits MySQL behavior
- [x] Existing MySQL and PostgreSQL adapters unaffected